### PR TITLE
store last block number in a file

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -96,11 +96,10 @@ jobs:
         env:
           SSH_DEPLOY_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
         with:
-          source-directory: neume-network-data/results
+          source-directory: neume-network-data
           destination-github-username: "neume-network"
           destination-repository-name: "data"
           user-email: info@neume.network
-          target-directory: results
           target-branch: ${{ github.ref_name }}
           commit-message: |
             Update from ${{github.server_url}}/${{github.repository}}/commit/${{github.sha}}

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -92,15 +92,11 @@ jobs:
         shell: bash
         run: mv neume-network-data/results/music-os-accumulator-extraction-new neume-network-data/results/music-os-accumulator-extraction
       - name: Update neume-network/data
-        uses: cpina/github-action-push-to-another-repository@main
-        env:
-          SSH_DEPLOY_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
-        with:
-          source-directory: neume-network-data
-          destination-github-username: "neume-network"
-          destination-repository-name: "data"
-          user-email: info@neume.network
-          target-branch: ${{ github.ref_name }}
-          commit-message: |
-            Update from ${{github.server_url}}/${{github.repository}}/commit/${{github.sha}}
-            ${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}
+        run: |
+          cd neume-network-data
+          git config user.email info@neume.network
+          git config user.name neume-network
+          git add results/* scripts/lastBlockNumber
+          git commit -m "Update from ${{github.server_url}}/${{github.repository}}/commit/${{github.sha}}" -m "${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
+          git push origin HEAD:${{ github.ref_name }}
+

--- a/scripts/generateBlockLogsCrawlPath
+++ b/scripts/generateBlockLogsCrawlPath
@@ -1,10 +1,20 @@
 #!/bin/bash
 # $(()) parses a hexadecimal number to a decimal
-lastBlockNumber=$(($(./lastBlockNumber)+1));
-blockNumber=$(($(./blockNumber)));
+
+lastBlockNumber=$(($(./lastBlockNumber)));
+
+blockNumber_16=$(./blockNumber);
+blockNumber=$((blockNumber_16));
+
+# update lastBlockNumber file with the latest block number
+sed -i -e "s/0x[a-fA-F0-9]*/$blockNumber_16/g" ./lastBlockNumber;
+
 step0="[{name: \"call-block-logs\",extractor: {args: [${lastBlockNumber}, ${blockNumber}]}}]";
+
 artistRegistry="0x78e3adc0e811e4f93bd9f1f9389b923c9a3355c2";
 artistCreateEvent="0x23748b43b77f98380e738976c6324996908ffc1989994dd3c68631c87a65a7c0";
 step1="[{name: \"soundxyz-filter-contracts\",transformer: {args: [\"${DATA_DIR}/call-block-logs-extraction\", \"${artistRegistry}\", \"${artistCreateEvent}\"]}}]";
+
 crawlpath="export default [${step0}, ${step1}];";
+
 echo $crawlpath;

--- a/scripts/lastBlockNumber
+++ b/scripts/lastBlockNumber
@@ -1,8 +1,3 @@
 #!/bin/bash
-# To get the last ten lines of the transformation file, we're using tail with
-# n=default, then grep a line that contains a blockNumber, match its content and
-# then extract the last value from the pipe.
-tail ../results/call-block-logs-transformation |\
-grep -o '"blockNumber":"[^"]*' |\
-grep -o '[^"]*$' |\
-tail -1
+# the last crawl ran till this block number
+echo "0xed8de5"


### PR DESCRIPTION
This PR fixes #46 by storing the last block number till which the crawl ran. I have tested the change in the [dev branch](https://github.com/neume-network/data/commits/dev).

#### Why store it in a file as opposed to the approach mentioned at https://github.com/neume-network/data/issues/46#issuecomment-1247911444?

If we read the call-block-logs-transformation file then the `lastBlockNumber` will be the last block number on which we found an NFT and not the block number till which we ran the scan. This can lead to re-crawling of blocks.

#### Why remove `cpina/github-action-push-to-another-repository`?

The last block number is stored in `scripts/lastBlockNumber` and we need to commit that. Currently the github action only commits changes in the `results` directory. If I removed `source-directory` then it would also commit [`steps/0.mjs`](https://github.com/neume-network/data/commit/da8840d3981f702be10629560d3a79f305d230ab#diff-390d32e3ee8c2545a065c42bdd85b9f2cdc358dcad7c784b4b434012c9938fce). Instead of using a hack to omit `steps/0.mjs` I chose to simply use `git` commands which provide greater control.

Note: Before merging this PR we will have to change the block number in `scripts/lastBlockNumber` to the last block number crawled by the main branch.